### PR TITLE
[BUGFIX] delete remote file and folder before delete locale

### DIFF
--- a/Classes/Distributor.php
+++ b/Classes/Distributor.php
@@ -15,15 +15,15 @@ use TYPO3\CMS\Core\Resource\Event\AfterFileAddedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFileContentsSetEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFileCopiedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFileCreatedEvent;
-use TYPO3\CMS\Core\Resource\Event\AfterFileDeletedEvent;
+use TYPO3\CMS\Core\Resource\Event\BeforeFileDeletedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFileMovedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFileRenamedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFolderAddedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFolderCopiedEvent;
-use TYPO3\CMS\Core\Resource\Event\AfterFolderDeletedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFolderMovedEvent;
 use TYPO3\CMS\Core\Resource\Event\AfterFolderRenamedEvent;
+use TYPO3\CMS\Core\Resource\Event\BeforeFolderDeletedEvent;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -58,7 +58,7 @@ class Distributor
         // @todo: should we do something about this?
     }
 
-    public function deleteFile(AfterFileDeletedEvent $event): void
+    public function deleteFile(BeforeFileDeletedEvent $event): void
     {
         $this->deleteFileFromRemotes($event->getFile());
     }
@@ -116,7 +116,7 @@ class Distributor
         // @todo
     }
 
-    public function deleteFolder(AfterFolderDeletedEvent $event): void
+    public function deleteFolder(BeforeFolderDeletedEvent $event): void
     {
         $folderPath = $event->getFolder()->getPublicUrl();
         foreach ($this->connector->getConnections($_SERVER['SERVER_ADDR']) as $connection) {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -25,7 +25,7 @@ services:
       - name: event.listener
         identifier: 'flysystem/delete-file'
         method: 'deleteFile'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFileDeletedEvent
+        event: TYPO3\CMS\Core\Resource\Event\BeforeFileDeletedEvent
       - name: event.listener
         identifier: 'flysystem/copy-file'
         method: 'copyFile'
@@ -57,7 +57,7 @@ services:
       - name: event.listener
         identifier: 'flysystem/delete-folder'
         method: 'deleteFolder'
-        event: TYPO3\CMS\Core\Resource\Event\AfterFolderDeletedEvent
+        event: TYPO3\CMS\Core\Resource\Event\BeforeFolderDeletedEvent
       - name: event.listener
         identifier: 'flysystem/add-folder'
         method: 'addFolder'


### PR DESCRIPTION
if local file is deleted, the method `$file->getForLocalProcessing(false);` throws an Exception.